### PR TITLE
BK-2: Fix BeKind impact stories placeholder

### DIFF
--- a/src/app/deed/comment-form/comment-form.component.html
+++ b/src/app/deed/comment-form/comment-form.component.html
@@ -3,7 +3,7 @@
     <ui-medium-editor
       [content]="content"
       (change)="change.emit($event)"
-      placeholder="Leave a testimony..."
+      [placeholder]="env.appId === 'liow' ? 'Leave a testimony...' : 'Leave a story of impact...'"
     ></ui-medium-editor>
 
     <button

--- a/src/app/deed/comment-form/comment-form.component.html
+++ b/src/app/deed/comment-form/comment-form.component.html
@@ -3,14 +3,10 @@
     <ui-medium-editor
       [content]="content"
       (change)="change.emit($event)"
-      [placeholder]="env.appId === 'liow' ? 'Leave a testimony...' : 'Leave a story of impact...'"
+      [placeholder]="env.appId === 'liow' ? 'Leave a testimony...' : 'Leave an impact story...'"
     ></ui-medium-editor>
 
-    <button
-      type="submit"
-      class="btn btn-primary m-t-xs"
-      [disabled]="!content || isSaving"
-    >
+    <button type="submit" class="btn btn-primary m-t-xs" [disabled]="!content || isSaving">
       <i class="fa fa-fw fa-cog fa-spin" [hidden]="!isSaving"></i>
       Save
     </button>

--- a/src/app/deed/comment-form/comment-form.component.spec.ts
+++ b/src/app/deed/comment-form/comment-form.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { MediumEditorStubComponent } from '../../../testing';
+import { EnvironmentService } from '../../core/services/environment.service';
 import { CommentFormComponent } from './comment-form.component';
 
 describe(`CommentFormComponent`, () => {
@@ -18,6 +19,7 @@ describe(`CommentFormComponent`, () => {
           TestHostComponent,
           MediumEditorStubComponent,
         ],
+        providers: [EnvironmentService],
       })
       .compileComponents();
   }));

--- a/src/app/deed/comment-form/comment-form.component.ts
+++ b/src/app/deed/comment-form/comment-form.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
+import { EnvironmentService } from '../../core/services/environment.service';
+
 @Component({
   selector: 'liow-comment-form',
   templateUrl: './comment-form.component.html',
@@ -10,4 +12,6 @@ export class CommentFormComponent {
   @Input() isSaving: boolean;
   @Output() change = new EventEmitter<string>();
   @Output() save = new EventEmitter<string>();
+
+  constructor(public env: EnvironmentService) {}
 }


### PR DESCRIPTION
## Summary
- Updates the deed comment form placeholder so BeKind shows **Leave a story of impact...** instead of **Leave a testimony...**
- Keeps LIOW wording unchanged via the existing `env.appId` pattern used elsewhere in the app
- Fixes [BK-2](https://linear.app/liow/issue/BK-2/bekind-impact-stories-placeholder-still-says-leave-a-testimony)

## Test plan
- [ ] On BeKind staging, open a deed while logged in and confirm the comment editor placeholder reads "Leave a story of impact..."
- [ ] On LIOW, confirm the placeholder still reads "Leave a testimony..."


Made with [Cursor](https://cursor.com)